### PR TITLE
Gggg 430 fix langfuse

### DIFF
--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -14,6 +14,7 @@ import requests
 import tiktoken
 from botocore.config import Config
 from fastapi import HTTPException
+from langfuse import Langfuse
 from langfuse.decorators import langfuse_context, observe
 from starlette.concurrency import run_in_threadpool
 
@@ -53,6 +54,18 @@ from api.setting import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Explicitly initialize Langfuse client for @observe decorator
+# This ensures the consumer and auth check happen at module load time
+try:
+    _langfuse = Langfuse(
+        debug=DEBUG
+    )
+    if DEBUG:
+        logger.info("Langfuse client initialized successfully")
+except Exception as e:
+    logger.warning(f"Failed to initialize Langfuse client: {e}")
+    _langfuse = None
 
 config = Config(
             connect_timeout=60,      # Connection timeout: 60 seconds

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -59,6 +59,9 @@ logger = logging.getLogger(__name__)
 # This ensures the consumer and auth check happen at module load time
 try:
     _langfuse = Langfuse(
+        public_key=os.environ.get("LANGFUSE_PUBLIC_KEY"),
+        secret_key=os.environ.get("LANGFUSE_SECRET_KEY"),
+        host=os.environ.get("LANGFUSE_HOST"),
         debug=DEBUG
     )
     if DEBUG:

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -14,7 +14,7 @@ import requests
 import tiktoken
 from botocore.config import Config
 from fastapi import HTTPException
-from langfuse.decorators import observe, langfuse_context
+from langfuse import observe, get_client
 from starlette.concurrency import run_in_threadpool
 
 from api.models.base import BaseChatModel, BaseEmbeddingsModel
@@ -53,6 +53,20 @@ from api.setting import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Initialize Langfuse client
+_langfuse_client = None
+
+def _get_langfuse_client():
+    """Get or create the Langfuse client singleton."""
+    global _langfuse_client
+    if _langfuse_client is None:
+        try:
+            _langfuse_client = get_client()
+        except Exception as e:
+            logger.warning(f"Failed to initialize Langfuse client: {e}")
+            _langfuse_client = None
+    return _langfuse_client
 
 config = Config(
             connect_timeout=60,      # Connection timeout: 60 seconds
@@ -253,18 +267,23 @@ class BedrockModel(BaseChatModel):
         }
         
         # Update Langfuse generation with input metadata
-        langfuse_context.update_current_observation(
-            input=messages,
-            model=model_id,
-            model_parameters=model_parameters,
-            metadata={
-                'system': args_clone.get('system', []),
-                'toolConfig': args_clone.get('toolConfig', {}),
-                'stream': stream
-            }
-        )
-        if DEBUG:
-            logger.info(f"Langfuse: Updated observation with input - model={model_id}, stream={stream}, messages_count={len(messages)}")
+        langfuse_client = _get_langfuse_client()
+        if langfuse_client:
+            try:
+                langfuse_client.update_current_generation(
+                    input=messages,
+                    model=model_id,
+                    model_parameters=model_parameters,
+                    metadata={
+                        'system': args_clone.get('system', []),
+                        'toolConfig': args_clone.get('toolConfig', {}),
+                        'stream': stream
+                    }
+                )
+                if DEBUG:
+                    logger.info(f"Langfuse: Updated observation with input - model={model_id}, stream={stream}, messages_count={len(messages)}")
+            except Exception as e:
+                logger.warning(f"Failed to update Langfuse: {e}")
 
         try:
             if stream:
@@ -302,41 +321,61 @@ class BedrockModel(BaseChatModel):
                         metadata["reasoning_content"] = reasoning_text
                         metadata["reasoning_tokens_estimate"] = len(reasoning_text) // 4
                     
-                    langfuse_context.update_current_observation(
-                        output=output_message,
-                        usage={
-                            "input": usage.get("inputTokens", 0),
-                            "output": usage.get("outputTokens", 0),
-                            "total": usage.get("totalTokens", 0)
-                        },
-                        metadata=metadata
-                    )
-                    if DEBUG:
-                        logger.info(f"Langfuse: Updated observation with output - "
-                                  f"input_tokens={usage.get('inputTokens', 0)}, "
-                                  f"output_tokens={usage.get('outputTokens', 0)}, "
-                                  f"has_reasoning={has_reasoning}, "
-                                  f"stop_reason={response.get('stopReason')}")
+                    langfuse_client = _get_langfuse_client()
+                    if langfuse_client:
+                        try:
+                            langfuse_client.update_current_generation(
+                                output=output_message,
+                                usage={
+                                    "input": usage.get("inputTokens", 0),
+                                    "output": usage.get("outputTokens", 0),
+                                    "total": usage.get("totalTokens", 0)
+                                },
+                                metadata=metadata
+                            )
+                            if DEBUG:
+                                logger.info(f"Langfuse: Updated observation with output - "
+                                          f"input_tokens={usage.get('inputTokens', 0)}, "
+                                          f"output_tokens={usage.get('outputTokens', 0)}, "
+                                          f"has_reasoning={has_reasoning}, "
+                                          f"stop_reason={response.get('stopReason')}")
+                        except Exception as e:
+                            logger.warning(f"Failed to update Langfuse: {e}")
         except bedrock_runtime.exceptions.ValidationException as e:
             error_message = f"Bedrock validation error for model {chat_request.model}: {str(e)}"
             logger.error(error_message)
-            langfuse_context.update_current_observation(level="ERROR", status_message=error_message)
-            if DEBUG:
-                logger.info(f"Langfuse: Updated observation with ValidationException error")
+            langfuse_client = _get_langfuse_client()
+            if langfuse_client:
+                try:
+                    langfuse_client.update_current_generation(level="ERROR", status_message=error_message)
+                    if DEBUG:
+                        logger.info(f"Langfuse: Updated observation with ValidationException error")
+                except Exception:
+                    pass
             raise HTTPException(status_code=400, detail=str(e))
         except bedrock_runtime.exceptions.ThrottlingException as e:
             error_message = f"Bedrock throttling for model {chat_request.model}: {str(e)}"
             logger.warning(error_message)
-            langfuse_context.update_current_observation(level="WARNING", status_message=error_message)
-            if DEBUG:
-                logger.info(f"Langfuse: Updated observation with ThrottlingException warning")
+            langfuse_client = _get_langfuse_client()
+            if langfuse_client:
+                try:
+                    langfuse_client.update_current_generation(level="WARNING", status_message=error_message)
+                    if DEBUG:
+                        logger.info(f"Langfuse: Updated observation with ThrottlingException warning")
+                except Exception:
+                    pass
             raise HTTPException(status_code=429, detail=str(e))
         except Exception as e:
             error_message = f"Bedrock invocation failed for model {chat_request.model}: {str(e)}"
             logger.error(error_message)
-            langfuse_context.update_current_observation(level="ERROR", status_message=error_message)
-            if DEBUG:
-                logger.info(f"Langfuse: Updated observation with generic Exception error")
+            langfuse_client = _get_langfuse_client()
+            if langfuse_client:
+                try:
+                    langfuse_client.update_current_generation(level="ERROR", status_message=error_message)
+                    if DEBUG:
+                        logger.info(f"Langfuse: Updated observation with generic Exception error")
+                except Exception:
+                    pass
             raise HTTPException(status_code=500, detail=str(e))
         return response
 
@@ -447,17 +486,21 @@ class BedrockModel(BaseChatModel):
                 if metadata:
                     update_params["metadata"] = metadata
                 
-                langfuse_context.update_current_observation(**update_params)
-                
-                if DEBUG:
-                    output_length = len(accumulated_output)
-                    logger.info(f"Langfuse: Updated observation with streaming output - "
-                              f"chunks_count={output_length}, "
-                              f"output_chars={len(final_output) if accumulated_output else 0}, "
-                              f"input_tokens={final_usage.prompt_tokens if final_usage else 'N/A'}, "
-                              f"output_tokens={final_usage.completion_tokens if final_usage else 'N/A'}, "
-                              f"has_reasoning={has_reasoning}, "
-                              f"finish_reason={finish_reason}")
+                langfuse_client = _get_langfuse_client()
+                if langfuse_client:
+                    try:
+                        langfuse_client.update_current_generation(**update_params)
+                        if DEBUG:
+                            output_length = len(accumulated_output)
+                            logger.info(f"Langfuse: Updated observation with streaming output - "
+                                      f"chunks_count={output_length}, "
+                                      f"output_chars={len(final_output) if accumulated_output else 0}, "
+                                      f"input_tokens={final_usage.prompt_tokens if final_usage else 'N/A'}, "
+                                      f"output_tokens={final_usage.completion_tokens if final_usage else 'N/A'}, "
+                                      f"has_reasoning={has_reasoning}, "
+                                      f"finish_reason={finish_reason}")
+                    except Exception as e:
+                        logger.warning(f"Failed to update Langfuse: {e}")
 
             # return an [DONE] message at the end.
             yield self.stream_response_to_bytes()
@@ -468,12 +511,17 @@ class BedrockModel(BaseChatModel):
         except Exception as e:
             logger.error("Stream error for model %s: %s", chat_request.model, str(e))
             # Update Langfuse with error
-            langfuse_context.update_current_observation(
-                level="ERROR",
-                status_message=f"Stream error: {str(e)}"
-            )
-            if DEBUG:
-                logger.info(f"Langfuse: Updated observation with streaming error - error={str(e)[:100]}")
+            langfuse_client = _get_langfuse_client()
+            if langfuse_client:
+                try:
+                    langfuse_client.update_current_generation(
+                        level="ERROR",
+                        status_message=f"Stream error: {str(e)}"
+                    )
+                    if DEBUG:
+                        logger.info(f"Langfuse: Updated observation with streaming error - error={str(e)[:100]}")
+                except Exception:
+                    pass
             error_event = Error(error=ErrorMessage(message=str(e)))
             yield self.stream_response_to_bytes(error_event)
 

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -14,7 +14,7 @@ import requests
 import tiktoken
 from botocore.config import Config
 from fastapi import HTTPException
-from langfuse import observe, langfuse_context
+from langfuse.decorators import observe, langfuse_context
 from starlette.concurrency import run_in_threadpool
 
 from api.models.base import BaseChatModel, BaseEmbeddingsModel

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -1,7 +1,8 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, Header, Request
 from fastapi.responses import StreamingResponse
+from langfuse.decorators import langfuse_context, observe
 
 from api.auth import api_key_auth
 from api.models.bedrock import BedrockModel
@@ -15,10 +16,58 @@ router = APIRouter(
 )
 
 
+def extract_langfuse_metadata(chat_request: ChatRequest, headers: dict) -> dict:
+    """Extract Langfuse tracing metadata from request body and headers.
+    
+    Metadata can be provided via:
+    1. extra_body.langfuse_metadata dict in the request
+    2. HTTP headers: X-Chat-Id, X-User-Id, X-Session-Id, X-Message-Id
+    3. user field in the request (for user_id)
+    
+    Returns a dict with: user_id, session_id, chat_id, message_id, and any custom metadata
+    """
+    metadata = {}
+    
+    # Extract from extra_body if present
+    if chat_request.extra_body and isinstance(chat_request.extra_body, dict):
+        langfuse_meta = chat_request.extra_body.get("langfuse_metadata", {})
+        if isinstance(langfuse_meta, dict):
+            metadata.update(langfuse_meta)
+    
+    # Extract from headers
+    headers_lower = {k.lower(): v for k, v in headers.items()}
+    
+    # Map headers to metadata fields - support both standard and OpenWebUI-prefixed headers
+    header_mapping = {
+        "x-chat-id": "chat_id",
+        "x-openwebui-chat-id": "chat_id",  # OpenWebUI sends this format
+        "x-user-id": "user_id",
+        "x-openwebui-user-id": "user_id",  # OpenWebUI sends this format
+        "x-session-id": "session_id",
+        "x-openwebui-session-id": "session_id",  # OpenWebUI sends this format
+        "x-message-id": "message_id",
+        "x-openwebui-message-id": "message_id",  # OpenWebUI sends this format
+    }
+    
+    for header_key, meta_key in header_mapping.items():
+        if header_key in headers_lower and headers_lower[header_key]:
+            # Don't override if already set (standard headers take precedence)
+            if meta_key not in metadata:
+                metadata[meta_key] = headers_lower[header_key]
+    
+    # Use the 'user' field from request as user_id if not already set
+    if "user_id" not in metadata and chat_request.user:
+        metadata["user_id"] = chat_request.user
+    
+    return metadata
+
+
 @router.post(
     "/completions", response_model=ChatResponse | ChatStreamResponse | Error, response_model_exclude_unset=True
 )
+@observe(as_type="generation", name="chat_completion")
 async def chat_completions(
+    request: Request,
     chat_request: Annotated[
         ChatRequest,
         Body(
@@ -34,12 +83,42 @@ async def chat_completions(
         ),
     ],
 ):
-    if chat_request.model.lower().startswith("gpt-"):
-        chat_request.model = DEFAULT_MODEL
+    # Extract metadata for Langfuse tracing
+    metadata = extract_langfuse_metadata(chat_request, dict(request.headers))
+    
+    # Create trace name using chat_id if available
+    trace_name = f"chat:{metadata.get('chat_id', 'unknown')}"
+    
+    # Update trace with metadata, user_id, and session_id
+    langfuse_context.update_current_trace(
+        name=trace_name,
+        user_id=metadata.get("user_id"),
+        session_id=metadata.get("session_id"),
+        metadata=metadata,
+        input={
+            "model": chat_request.model,
+            "messages": [msg.model_dump() for msg in chat_request.messages],
+            "temperature": chat_request.temperature,
+            "max_tokens": chat_request.max_tokens,
+            "tools": [tool.model_dump() for tool in chat_request.tools] if chat_request.tools else None,
+        }
+    )
 
     # Exception will be raised if model not supported.
     model = BedrockModel()
     model.validate(chat_request)
+    
     if chat_request.stream:
         return StreamingResponse(content=model.chat_stream(chat_request), media_type="text/event-stream")
-    return await model.chat(chat_request)
+    
+    response = await model.chat(chat_request)
+    
+    # Update trace with output for non-streaming
+    langfuse_context.update_current_trace(
+        output={
+            "message": response.choices[0].message.model_dump() if response.choices else None,
+            "finish_reason": response.choices[0].finish_reason if response.choices else None,
+        }
+    )
+    
+    return response

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -99,7 +99,7 @@ class ChatRequest(BaseModel):
     stream_options: StreamOptions | None = None
     temperature: float | None = Field(default=1.0, le=2.0, ge=0.0)
     top_p: float | None = Field(default=1.0, le=1.0, ge=0.0)
-    user: str | None = None  # Not used
+    user: str | None = None
     max_tokens: int | None = 2048
     max_completion_tokens: int | None = None
     reasoning_effort: Literal["low", "medium", "high"] | None = None

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ requests==2.32.4
 numpy==2.2.5
 boto3==1.40.4
 botocore==1.40.4
-langfuse
+langfuse>=2.0.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ requests==2.32.4
 numpy==2.2.5
 boto3==1.40.4
 botocore==1.40.4
-langfuse>=2.0.0
+langfuse<3.0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes Langfuse by initializing the client, shifting observation to the chat endpoint, and updating traces (input/output/usage/reasoning/errors) for streaming and non‑streaming; pins langfuse<3.0.0.
> 
> - **Observability / Tracing (Langfuse)**:
>   - Initialize `Langfuse` client at module load in `api/models/bedrock.py`.
>   - Add `@observe(name="chat_completion")` to `POST /chat/completions`; extract trace metadata from request body/headers via `extract_langfuse_metadata`; update current trace with request input and final output.
>   - Refactor Bedrock model to update `langfuse_context.update_current_trace` (not observation) in both `chat` and `chat_stream`, including `usage`, `stopReason/finish_reason`, and extended thinking metadata; add structured error updates during streaming.
> - **API**:
>   - Enable using `ChatRequest.user` for tracing metadata.
> - **Dependencies**:
>   - Pin `langfuse<3.0.0` in `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff97409ac96fc2e46ade24e34f08bcf6e97e7334. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->